### PR TITLE
feat: add support to import/export Policy data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /venv/
+.idea

--- a/iq-apply-conf.py
+++ b/iq-apply-conf.py
@@ -520,7 +520,6 @@ def add_policy(data, org='ROOT_ORGANIZATION_ID', app=None):
     if data is None or len(data) == 0 or app is not None:
         return
     url = f'{iq_url}/rest/policy/{org_or_app(org, app)}/import'
-    print(url)
     multipart_post_url(url, data)
 
 

--- a/iq-apply-conf.py
+++ b/iq-apply-conf.py
@@ -516,7 +516,8 @@ def add_source_control(data, org=None, app=None):
 
 
 def add_policy(data, org='ROOT_ORGANIZATION_ID', app=None):
-    if data is None or len(data) == 0:
+    # importing policy at the application level is not currently supported; only org
+    if data is None or len(data) == 0 or app is not None:
         return
     url = f'{iq_url}/rest/policy/{org_or_app(org, app)}/import'
     print(url)

--- a/iq-scrape-conf.py
+++ b/iq-scrape-conf.py
@@ -138,7 +138,9 @@ def org_configuration(org):
     orgconf['component_labels'] = persist_component_labels(org=org['id'])
     orgconf['license_threat_groups'] = persist_license_threat_groups(org=org['id'])
     orgconf['access'] = persist_access(org=org['id'])
+    orgconf['policy'] = persist_policy(org=org['id'])
     orgconf['name'] = org['name']
+    orgconf['policy'] = persist_policy()
     return orgconf
 
 
@@ -155,6 +157,7 @@ def app_configuration(app):
     app_conf['publicId'] = app['publicId']
     app_conf['applicationTags'] = check_categories(app['applicationTags'])
     app_conf['access'] = persist_access(app=app['id'])
+    app_conf['policy'] = persist_policy(app=app['id'])
     # persist_data(app_conf, f'{output_dir}{app["name"]}-config.json')
     return app_conf
 
@@ -456,6 +459,18 @@ def persist_source_control(org='ROOT_ORGANIZATION_ID', app=None):
     #     persist_data(data, f'{output_dir}{app["name"]}-source_control.json')
     # elif org is not None:
     #     persist_data(data, f'{output_dir}{get_organization_name(org)}-source_control.json')
+    print_debug(data)
+    return data
+
+def persist_policy(org='ROOT_ORGANIZATION_ID', app=None):
+    url = f'{iq_url}/rest/policy/{org_or_app(org, app)}/export'
+
+    data = get_url(url)
+    if data is not None:
+        for policy in data['policies']:
+            policy.pop('id')
+            for constraint in policy['constraints']:
+                constraint.pop('id')
     print_debug(data)
     return data
 

--- a/iq-scrape-conf.py
+++ b/iq-scrape-conf.py
@@ -464,6 +464,9 @@ def persist_source_control(org='ROOT_ORGANIZATION_ID', app=None):
 
 
 def persist_policy(org='ROOT_ORGANIZATION_ID', app=None):
+    if app is not None:
+        # app level policy import/export is not supported
+        return
     url = f'{iq_url}/rest/policy/{org_or_app(org, app)}/export'
     data = get_url(url)
     if data is not None:

--- a/iq-scrape-conf.py
+++ b/iq-scrape-conf.py
@@ -140,7 +140,6 @@ def org_configuration(org):
     orgconf['access'] = persist_access(org=org['id'])
     orgconf['policy'] = persist_policy(org=org['id'])
     orgconf['name'] = org['name']
-    orgconf['policy'] = persist_policy()
     return orgconf
 
 

--- a/iq-scrape-conf.py
+++ b/iq-scrape-conf.py
@@ -462,9 +462,9 @@ def persist_source_control(org='ROOT_ORGANIZATION_ID', app=None):
     print_debug(data)
     return data
 
+
 def persist_policy(org='ROOT_ORGANIZATION_ID', app=None):
     url = f'{iq_url}/rest/policy/{org_or_app(org, app)}/export'
-
     data = get_url(url)
     if data is not None:
         for policy in data['policies']:


### PR DESCRIPTION
This changeset includes the capability to import and export policy data. This feature works at the root organization or child organizations, but it does not work for policies set at the application level as the IQ Server API does not support policy import at that level.