### PR TITLE
add container build github workflow

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,30 @@
+name: container build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  container-build:
+    name: container build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
As mentioned in https://github.com/sonatype-nexus-community/iq-config-as-code/pull/16#issuecomment-933194698 i don't want to support the container image host by myself. With this change you are able to support it by your own.